### PR TITLE
nfs-kernel-server - failed to init nfsdcltrack database

### DIFF
--- a/debian/nfs-common.install
+++ b/debian/nfs-common.install
@@ -20,6 +20,7 @@ debian/tmp/var/lib/nfs/state
 debian/idmapd.conf usr/share/nfs-common/conffiles/
 debian/nfs-common.default usr/share/nfs-common/conffiles/
 debian/id_resolver.conf etc/request-key.d/
+debian/nfs-server-prep.sh /usr/lib/systemd/scripts/
 debian/nfs-utils_env.sh /usr/lib/systemd/scripts/
 systemd/*.mount /lib/systemd/system
 systemd/*rpc*.service /lib/systemd/system

--- a/debian/nfs-server-prep.sh
+++ b/debian/nfs-server-prep.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+#
+# Copyright 2019 Delphix
+#
+
+#
+# Called by the nfs-server.service unit before the server is started
+#
+
+#
+# DLPX-64900
+# Work around for kernel failing to parse the 'versions' input string
+# "-4.1 -4.2 -2 +3 +4" that is passed from rpc.nfsd after a reboot
+#
+# Prime the kernel version after a reboot to include +4 so that the -4.x works
+#
+# We need this work-around until Ubuntu picks up nfs-utils 2.3.3
+#
+versions=$(cat /proc/fs/nfsd/versions)
+if [[ "$versions" == "-2 -3 -4 -4.0 -4.1 -4.2" ]]; then
+	echo "Initializing the NFS server version"
+	printf '+4\n' >/proc/fs/nfsd/versions
+fi
+
+#
+# DLPX-65853
+# Due to a permissions error, where '/var/lib/nfs' is owned by statd, the
+# database used by nfsdcltrack(8) is never initialized.  This database is
+# necessary for the NFSv4 server to track clients and notify them when the
+# server is restarted.
+#
+# The work around is to create the directory that holds the client tracking
+# database upfront to avoid the mkdir failure during the nfsdcltrack init.
+#
+NFSD_CL_TRACK_DIR="/var/lib/nfs/nfsdcltrack"
+if [[ ! -d "$NFSD_CL_TRACK_DIR" ]]; then
+	echo Creating dir for fsdcltrack database
+	mkdir "$NFSD_CL_TRACK_DIR"
+fi
+
+exit 0

--- a/debian/rules
+++ b/debian/rules
@@ -71,6 +71,7 @@ binary-arch: build
 	dh_strip
 	dh_compress
 	dh_fixperms
+	chmod +x debian/nfs-common/usr/lib/systemd/scripts/nfs-server-prep.sh
 	chmod +x debian/nfs-common/usr/lib/systemd/scripts/nfs-utils_env.sh
 	chmod u+s debian/nfs-common/sbin/mount.nfs
 	dh_installdeb

--- a/systemd/nfs-server.service
+++ b/systemd/nfs-server.service
@@ -26,6 +26,7 @@ EnvironmentFile=-/run/sysconfig/nfs-utils
 
 Type=oneshot
 RemainAfterExit=yes
+ExecStartPre=/usr/lib/systemd/scripts/nfs-server-prep.sh
 ExecStartPre=/usr/sbin/exportfs -r
 ExecStart=/usr/sbin/rpc.nfsd $RPCNFSDARGS
 ExecStop=/usr/sbin/rpc.nfsd 0


### PR DESCRIPTION
DLPX-65853 nfs-kernel-server - failed to init nfsdcltrack database
DLPX-64900 rpc.nfsd ignores no-nfs-version parameter at reboot

**Description**
Due to a permissions error, where `/var/lib/nfs` is owned by `statd` user, the database used by `nfsdcltrack(8)` is never initialized. The kernel nfs server code invokes `/sbin/nfsdcltrack` to initialize the database, which in turn fails when trying to make the containing `nfsdcltrack` directory.

This database is necessary for the NFSv4 server to track clients and notify them when the server is restarted. The work around is to create the directory that holds the client tracking database upfront.

**Note**
We could add our work-arounds to the existing `nfs-utils_env.sh` file.  However that file is removed in upstream revisions, so our changes could get dropped in a future upstream update. As a precaution we create a new file, `nfs-server-prep.sh`, to host our work arounds.

**Testing**
Used `git-linux-pkg build` to install on target host
Manually tested the work around to confirm that the database is initialized.

ab-pre-push results:
http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/2093/