### PR TITLE
DLPX-67480 nfs server is restarted multiple times during upgrade

### DIFF
--- a/debian/nfs-kernel-server.postinst
+++ b/debian/nfs-kernel-server.postinst
@@ -14,11 +14,5 @@ case "$1" in
 		 /var/lib/nfs/xtab; do
 	    [ -e $f ] || touch $f
 	done
-
-	update-rc.d nfs-kernel-server defaults 20 80 >/dev/null
     ;;
 esac
-
-act="restart"
-[ "$1:$2" = "configure:" ] && act="start"
-invoke-rc.d nfs-kernel-server $act || echo "Failed to ${act} nfs-kernel-server, ignoring."

--- a/debian/nfs-kernel-server.postrm
+++ b/debian/nfs-kernel-server.postrm
@@ -6,8 +6,6 @@ set -e
 
 case "$1" in
     purge)
-	update-rc.d nfs-kernel-server remove >/dev/null
-
 	for FILE in /etc/default/nfs-kernel-server /etc/exports; do
 	    # Taken from the ucf example postrm
 	    for ext in '~' '%' .bak .dpkg-tmp .dpkg-new .dpkg-old .dpkg-dist;  do

--- a/debian/nfs-kernel-server.prerm
+++ b/debian/nfs-kernel-server.prerm
@@ -4,13 +4,6 @@ set -e
 
 #DEBHELPER#
 
-case "$1" in
-    remove|purge)
-	[ -x /etc/init.d/nfs-kernel-server ] &&
-	    invoke-rc.d nfs-kernel-server stop
-	;;
-esac
-
 if [ "$1" != upgrade ]
 then
     rm -f /var/lib/nfs/etab   \


### PR DESCRIPTION
Currently, the packaging hooks attempt to manipulate the NFS server
service multiple times. This is because they have the "#DEBHELPER#"
entry in the script, which causes systemd service manipulation to get
automatically added to the scripts, and then have additional logic in
the scripts to do the same thing.

This change removes the explicit logic that manipulates the service from
the package hooks, in favor of relying on "#DEBHELPER#" to provide that
logic.