### PR TITLE
Emit "xtrace" information from NFS package hooks

### DIFF
--- a/debian/nfs-common.postinst
+++ b/debian/nfs-common.postinst
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 case "$1" in
     configure)

--- a/debian/nfs-common.postinst
+++ b/debian/nfs-common.postinst
@@ -42,4 +42,6 @@ case "$1" in
     ;;
 esac
 
+exportfs -s || true
 #DEBHELPER#
+exportfs -s || true

--- a/debian/nfs-common.postrm
+++ b/debian/nfs-common.postrm
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 #DEBHELPER#
 

--- a/debian/nfs-common.postrm
+++ b/debian/nfs-common.postrm
@@ -3,7 +3,9 @@
 set -e
 set -x
 
+exportfs -s || true
 #DEBHELPER#
+exportfs -s || true
 
 case "$1" in
     purge)

--- a/debian/nfs-common.prerm
+++ b/debian/nfs-common.prerm
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 #DEBHELPER#
 

--- a/debian/nfs-common.prerm
+++ b/debian/nfs-common.prerm
@@ -3,7 +3,9 @@
 set -e
 set -x
 
+exportfs -s || true
 #DEBHELPER#
+exportfs -s || true
 
 if [ "$1" = remove ]
 then

--- a/debian/nfs-kernel-server.postinst
+++ b/debian/nfs-kernel-server.postinst
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 #DEBHELPER#
 

--- a/debian/nfs-kernel-server.postinst
+++ b/debian/nfs-kernel-server.postinst
@@ -3,7 +3,9 @@
 set -e
 set -x
 
+exportfs -s || true
 #DEBHELPER#
+exportfs -s || true
 
 case "$1" in
     configure)

--- a/debian/nfs-kernel-server.postrm
+++ b/debian/nfs-kernel-server.postrm
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 #DEBHELPER#
 

--- a/debian/nfs-kernel-server.postrm
+++ b/debian/nfs-kernel-server.postrm
@@ -3,7 +3,9 @@
 set -e
 set -x
 
+exportfs -s || true
 #DEBHELPER#
+exportfs -s || true
 
 case "$1" in
     purge)

--- a/debian/nfs-kernel-server.prerm
+++ b/debian/nfs-kernel-server.prerm
@@ -1,6 +1,7 @@
 #!/bin/sh
 
 set -e
+set -x
 
 #DEBHELPER#
 

--- a/debian/nfs-kernel-server.prerm
+++ b/debian/nfs-kernel-server.prerm
@@ -3,7 +3,9 @@
 set -e
 set -x
 
+exportfs -s || true
 #DEBHELPER#
+exportfs -s || true
 
 if [ "$1" != upgrade ]
 then


### PR DESCRIPTION
To better enable us to observe exactly what occurs during upgrade, this
change adds "set -x" to the NFS package hooks, which allows us to see
the specific commands that're executed when the NFS package is upgraded.