### PR TITLE
DLPX-76288 Increase NFS worker threads

### DIFF
--- a/debian/nfs-utils_env.sh
+++ b/debian/nfs-utils_env.sh
@@ -6,6 +6,15 @@ nfs_config=/etc/sysconfig/nfs
 [ -r /etc/default/nfs-common ] && . /etc/default/nfs-common
 [ -r /etc/default/nfs-kernel-server ] && . /etc/default/nfs-kernel-server
 
+#
+# Delphix Engine Override
+# On smaller memory systems (i.e. <= 32G) limit the NFSD thread count
+#
+system_memory=$(awk '/MemTotal/ { printf "%d \n", $2/1024/1024 }' /proc/meminfo)
+if [ "$system_memory" -le 32 ] && [ "${RPCNFSDCOUNT}" > 64 ]; then
+        RPCNFSDCOUNT=64
+fi
+
 mkdir -p /run/sysconfig
 {
 echo PIPEFS_MOUNTPOINT=/run/rpc_pipefs


### PR DESCRIPTION
# Context:
Part of solution for:  **DLPX-76288** Increase NFS worker threads
# Problem:
Our default of 64 `nfsd` worker threads proved to be insufficient in a recent customer escalation.  As part of that investigation we came up with 512 threads as a more reasonable target.  In DLPX-76288 it increases the thread count to 512.  However, on smaller memory systems, like our test images, it makes sense to leave the thread count at 64.

# Solution:
On smaller memory systems (i.e. <= 32G) limit the NFSD thread count.

This is a simple change to the existing nfs-utils_env.sh script that is generating the runtime config data that the nfs-server consumes. If the memory is less than 32G then override any thread count larger than 64.

# Testing
ab-pre-push:
  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5773/

Also tested with self-service `pre_checkin` with both changes in place (this one and DLPX-76288).
  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/blackbox-self-service/102539/consoleFull

Also manually tested the script with smaller and larger memory and with the default threads set to > 64.
# Deployment Plan:
It is expected to land this change first, then push DLPX-76288.  However, the changes are independent and no flag day is required.
