### PR TITLE
DLPX-76619 Omit reverse ip address lookups in rpc.statd monitoring request

### DIFF
--- a/utils/statd/notlist.c
+++ b/utils/statd/notlist.c
@@ -232,9 +232,18 @@ nlist_gethost(notify_list *list, char *host, int myname)
 	notify_list	*lp;
 
 	for (lp = list; lp; lp = lp->next) {
-		if (statd_matchhostname(host,
-				myname? NL_MY_NAME(lp) : NL_MON_NAME(lp)))
-			return lp;
+		if (!myname) {
+			/*
+			 * Use a matching function that doesn't perform reverse
+			 * lookups for ip addresses.
+			 */
+			if (statd_matchhostname_pa(host, NL_MON_NAME(lp)))
+				return lp;
+		} else {
+			if (statd_matchhostname(host, myname? NL_MY_NAME(lp) :
+					NL_MON_NAME(lp)))
+				return lp;
+		}
 	}
 
 	return (notify_list *) NULL;

--- a/utils/statd/statd.h
+++ b/utils/statd/statd.h
@@ -23,6 +23,7 @@
  * Function prototypes.
  */
 extern _Bool	statd_matchhostname(const char *hostname1, const char *hostname2);
+extern _Bool	statd_matchhostname_pa(const char *hostname1, const char *hostname2);
 extern _Bool	statd_present_address(const struct sockaddr *sap, char *buf,
 					const size_t buflen);
 __attribute__((__malloc__))


### PR DESCRIPTION
# Context:
During ESCL-3575 we discovered that a monitoring request to `rpc.statd` from `lockd` was performing a reverse ip lookup when the `mon_name` was an ip address.  The DNS lookup request was _inline_ during the lock request and a stall in the resolver/DNS path was triggering a timeout for the lock request and denying the lock.

# Solution:
The reverse ip lookup is optional and the results are primarily used for a canonical filename in the sm notify list directory.  Since ip addresses are themselves unique we don't need to use a reverse lookup name.  That is, always use the ip address for the filename whether there was a reverse DNS entry or not (see example in testing section).

In addition there was a reverse ip lookup when matching a new `mon_name` against existing notify list entries (in the contents of the notify list entry).  This extra lookup was to see if the hostnames being compared belong to the same canonical name (multipath). This is not a concern for the appliance use case and even in that case you could have effective duplicate entries which is benign since this is only a notify list and sending two notifications is acceptable.

# Testing
ab-pre-push:
  http://selfservice.jenkins.delphix.com/job/devops-gate/job/master/job/appliance-build-orchestrator-pre-push/5852/

Manual testing with NFSv3  clients that
- had ip addresses that had DNS reverse lookup entries (dcol-dev)
- did not have any DNS entries for the ip address

Example:
**Before** -- reverse lookup of ip address is used for filename (i.e. notify list key)
```
delphix@ip-10-110-195-158:~/nfs-utils$ sudo cat /var/lib/nfs/sm/dcol-dev.delphix.com
0100007f 000186b5 00000003 00000010 4a9195d97d2e0000008c1b0c2495ffff 172.16.104.215 ip-10-110-195-158
```
**After** -- no reverse lookup, use ip address as-is for filename
```
delphix@ip-10-110-195-158:~$ sudo cat /var/lib/nfs/sm/172.16.104.215
0100007f 000186b5 00000003 00000010 2269fc8c972e0000009ab0042495ffff 172.16.104.215 ip-10-110-195-158
```
# Implementation:
Added `statd_matchhostname_pa()` function (pa for presentation address) which will avoid the reverse ip lookups during `SM_MON`/`SM_UNMON` requests.  Note that the original `statd_matchhostname()` is used elsewhere in nfs-utils so a new routine was added for the statd case.