### PR TITLE
DLPX-76685 [Backport of DLPX-76619 to 6.0.10.0] Omit reverse ip address lookups

### DIFF
--- a/utils/statd/notlist.c
+++ b/utils/statd/notlist.c
@@ -232,9 +232,18 @@ nlist_gethost(notify_list *list, char *host, int myname)
 	notify_list	*lp;
 
 	for (lp = list; lp; lp = lp->next) {
-		if (statd_matchhostname(host,
-				myname? NL_MY_NAME(lp) : NL_MON_NAME(lp)))
-			return lp;
+		if (!myname) {
+			/*
+			 * Use a matching function that doesn't perform reverse
+			 * lookups for ip addresses.
+			 */
+			if (statd_matchhostname_pa(host, NL_MON_NAME(lp)))
+				return lp;
+		} else {
+			if (statd_matchhostname(host, myname? NL_MY_NAME(lp) :
+					NL_MON_NAME(lp)))
+				return lp;
+		}
 	}
 
 	return (notify_list *) NULL;

--- a/utils/statd/statd.h
+++ b/utils/statd/statd.h
@@ -23,6 +23,7 @@
  * Function prototypes.
  */
 extern _Bool	statd_matchhostname(const char *hostname1, const char *hostname2);
+extern _Bool	statd_matchhostname_pa(const char *hostname1, const char *hostname2);
 extern _Bool	statd_present_address(const struct sockaddr *sap, char *buf,
 					const size_t buflen);
 __attribute__((__malloc__))


### PR DESCRIPTION
The commit for #11 was inadvertently dropped from 6.0/stage during the move to Ubuntu 20.04

This clean cherry-pick from master brings back the changes for #11 into the 6.0/stage branch.

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/719/
