### PR TITLE
DLPX-79316 add finer grain cache control to exportfs

### DIFF
--- a/support/include/nfslib.h
+++ b/support/include/nfslib.h
@@ -156,6 +156,7 @@ struct nfs_fh_len *	getfh_size(const struct sockaddr_in *sin,
 int qword_get(char **bpp, char *dest, int bufsize);
 int qword_get_int(char **bpp, int *anint);
 void cache_flush(int force);
+void cache_flush_entry(const char *entry);
 int check_new_cache(void);
 void qword_add(char **bpp, int *lp, char *str);
 void qword_addhex(char **bpp, int *lp, char *buf, int blen);

--- a/utils/exportfs/exportfs.man
+++ b/utils/exportfs/exportfs.man
@@ -141,6 +141,14 @@ options.
 .TP
 .B -s
 Display the current export list suitable for /etc/exports.
+.TP
+.B -F <path>
+Flush a specific export from the NFSD caches.
+.TP
+.B -N
+Do not flush the NFSD caches when adding/removing exports. A follow on
+.BR "exportfs -F <path>"
+is used to flush a specific entry.
 .SH DISCUSSION
 .SS Exporting Directories
 The first synopsis shows how to invoke


### PR DESCRIPTION
# Motivation and Context
When an NFS share is added/removed it has the side-effect of having all NFSD caching purged. This in turn can impact NFS performance as each NFSD thread has to wait to recreate cache entries by making upcalls to `rpc.mountd`.  The higher the number of exports and NFS traffic, the greater the impact, as has been observed on DCoL hosts.

# Solution:
The goal is to only flush the cache entries for the exports being removed to minimize the disruptions to other active NFS mounts.

**Exportfs changes**
Added a new `'-N'` option that avoids the cache purges after a rebuild
Added a new `'-F'` option that allows flushing entries associated with a specific export

Note -- in addition to the `nfsd.fh` and` nfsd.export` caches there is a file credentials cache that has no fine grain eviction logic.  The entries in that cache are evicted on the last file reference drop (`fput`), however the mount reference is dropped asynchronously by a background task that runs every few seconds.  

Since we are no longer purging the entire cache, we wait in `exportfs` when performing the  `'-F'` flush for these mount refs to be dropped.  If there was activity before the client unmount (or the unmount was lazy) then there will likely be some of these pending mount refs being processed. The small wait here (~ 2 seconds) is an acceptable trade for not interrupting the activity taking place of other NFS mounts.

# Testing
http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/1556/

Testing on on dcol-dev:
- dc clone/destroy workflows
- Blackbox runs with an engine cloned on dcol-dev
- Confirmed that the NFSD caches are not being purged but that zfs destroys succeed

# Deployment Plan:
The changes here and the corresponding changes in `libshare` can land independently. There is a check in `libshare` to confirm that `exportfs` supports the finer grain cache control before making use of it.