### PR TITLE
DLPX-82097 rpc.mountd consumes a lot of CPU time for clone/destroy on DCoL

### DIFF
--- a/support/include/nfslib.h
+++ b/support/include/nfslib.h
@@ -97,6 +97,8 @@ struct exportent {
 	char *		e_uuid;
 	struct sec_entry e_secinfo[SECFLAVOR_COUNT+1];
 	unsigned int	e_ttl;
+	/* cache the fsid to avoid excessive statfs calls */
+	char		e_fsid_value[17];
 };
 
 struct rmtabent {

--- a/support/misc/mountpoint.c
+++ b/support/misc/mountpoint.c
@@ -22,6 +22,17 @@ is_mountpoint(char *path)
 	struct stat stb, pstb;
 	int rv;
 
+	/*
+	 * Delphix appliance exports are always an active mountpoint, except
+	 * for appdata, so for those paths we can avoid the excessive double
+	 * lstat() calls used here to determine mountpoint status.
+	 */
+	if ((strncmp(path, "/domain0/", 9) == 0 &&
+	    strstr(path, "appdata_timeflow") == NULL) ||
+	    strncmp(path, "/dcenter/", 9) == 0) {
+		return 1;
+	}
+
 	dotdot = xmalloc(strlen(path)+4);
 
 	strcat(strcpy(dotdot, path), "/..");

--- a/support/nfs/exports.c
+++ b/support/nfs/exports.c
@@ -101,6 +101,7 @@ static void init_exportent (struct exportent *ee, int fromkernel)
 	ee->e_nsqgids = 0;
 	ee->e_uuid = NULL;
 	ee->e_ttl = DEFAULT_TTL;
+	ee->e_fsid_value[0] = '\0';
 }
 
 struct exportent *

--- a/utils/mountd/v4root.c
+++ b/utils/mountd/v4root.c
@@ -48,6 +48,7 @@ static nfs_export pseudo_root = {
 		.e_fsid = 0,
 		.e_mountpoint = NULL,
 		.e_ttl = DEFAULT_TTL,
+		.e_fsid_value = "",
 	},
 	.m_exported = 0,
 	.m_xtabent = 1,


### PR DESCRIPTION
DLPX-82097 rpc.mountd consumes a lot of CPU time for clone/destroy on DCoL


# Context:
As described in DLPX-82097 and TOOL-12000, whenever a zfs dataset is exported or unexported, it causes NFS to purge all its caching. The subsequent repopulation of the caches causes a `stat()` call storm (millions of stat calls) that impacts NFS I/O performance.

# Problem:
When adding an entry to the cache in `rpc.mountd`, it makes multiple stat calls against each entry in the list of exports. For example, if there are a 1,000 exports, adding an entry into the cache will make 5 x 1,000 stat calls.  If there are thousands of new cache entires to add, this will cause a storm of stat calls.

# Solution:
**Part 1**: 
We know that any exports under `/dcenter` or `/domain0` will always be a mountpoint (i.e. always a dataset that is being exported).  Therefore we can optimize the `is_mountpoint()` function to avoid calling `stat()` twice to determine if any export under `/dcenter` or `/domain0` is a mountpoint.

**Part 2**:
In the `uuid_by_path()` function it was calling `statfs()` to find the fsid for a given export.  Since the fsid is immutable, we can cache the result and avoid all future calls to `statfs()`.

Note -- the longterm solution is to engage the upstream developers of `nfs-utils` to come up with a more generic solution that benefits all use cases.

Jammy note -- these changes will also work for Jammy (nfs-utils v2.6).

# Testing
Deployed the new `rpc.mountd `on `dcol-dev` to confirm that the stat storm no longer occurs.

Additional manual testing using a 1,000 exports and monitoring with bfp tracing.

# Deployment Plan:
The plan is to land this in master branch of nfs-utils and then dcol1 can pick it up when it merges in the latest master.

# Future work:
Engage the upstream developers of `nfs-utils` to come up with a more generic solution that benefits all use cases.
