### PR TITLE
DLPX-83675 Cleanup stale entries in rmtab file

### DIFF
--- a/support/export/rmtab.c
+++ b/support/export/rmtab.c
@@ -12,6 +12,8 @@
 #include <stdlib.h>
 #include <string.h>
 #include <errno.h>
+#include <unistd.h>
+#include <sys/stat.h>
 
 #include "misc.h"
 #include "nfslib.h"
@@ -95,4 +97,119 @@ rmtab_read(void)
 		endrmtabent();
 	}
 	return 0;
+}
+
+/*
+ * Check if an rmtab_path is exported given an export_path from etab file.
+ * The path is considered exported if it is an exact match or is part of
+ * a path nested under an export.
+ */
+static int
+is_exported(const char* rmtab_path, const char* export_path) {
+	/* first check that rmtab_path starts with the export_path */
+	if (strstr(rmtab_path, export_path) != rmtab_path)
+		return 0;
+
+	/* then confirm that it is an exact match or that it's nested */
+	char next = rmtab_path[strlen(export_path)];
+	return next == '\0' || next == '/';
+}
+
+/*
+ * The rmtab file can acculmulate stale entries over time. So when the list of
+ * exports changes, make a best effort attempt to insure that every entry in
+ * rmtab has a corresonding export. This code is based off of mountlist_del().
+ */
+void
+rmtab_rebuild(void)
+{
+	struct rmtabent	*rep;
+	struct stat	stb;
+	FILE		*fp;
+	int		rmtab_lockid, etab_lockid;
+	int		entries_seen = 0, entries_copied = 0;
+	struct exportent *xp;
+	char		**e_path = NULL;
+	int		i, len = 0;
+
+	/* Hold locks for the rmtab and etab files during rebuilding */
+	if ((rmtab_lockid = xflock(_PATH_RMTABLCK, "w")) < 0)
+		return;
+
+	/* fast path for no NFSv3 mounts */
+	if (stat(_PATH_RMTAB, &stb) < 0 || stb.st_size == 0) {
+		xfunlock(rmtab_lockid);
+		return;
+	}
+
+	if ((etab_lockid = xflock(_PATH_ETABLCK, "r")) < 0) {
+		xfunlock(rmtab_lockid);
+		return;
+	}
+
+	if (!setrmtabent("r")) {
+		xfunlock(rmtab_lockid);
+		xfunlock(etab_lockid);
+		return;
+	}
+	if (!(fp = fsetrmtabent(_PATH_RMTABTMP, "w"))) {
+		endrmtabent();
+		xfunlock(rmtab_lockid);
+		xfunlock(etab_lockid);
+		return;
+	}
+
+	/* build a list of exported paths */
+	setexportent(_PATH_ETAB, "r");
+	while ((xp = getexportent(0, 0)) != NULL) {
+		if ((len % 8) == 0) {
+			e_path = (char **) realloc(e_path,
+			    (len + 8) * sizeof(*e_path));
+		}
+		e_path[len++] = strdup(xp->e_path);
+	}
+	endexportent();
+
+	/* Visit all the entries in rmtab file */
+	while ((rep = getrmtabent(1, NULL)) != NULL) {
+		int saved = 0;
+
+		/* filter entries that are not exported */
+		for (int i = 0; i < len; i++) {
+			if (is_exported(rep->r_path, e_path[i])) {
+				fputrmtabent(fp, rep, NULL);
+				entries_copied++;
+				saved = 1;
+				break;
+			}
+		}
+		entries_seen++;
+
+		if (!saved) {
+			/* log this stale cleanup to the syslog file */
+			xlog_syslog(1);
+			xlog(L_NOTICE, "purged stale rmtab entry '%s:%s'",
+			    rep->r_client, rep->r_path);
+			xlog_syslog(0);
+		}
+	}
+	endrmtabent();
+	fendrmtabent(fp);
+
+	if (entries_seen != entries_copied) {
+		if (rename(_PATH_RMTABTMP, _PATH_RMTAB) < 0) {
+			xlog(L_ERROR, "couldn't rename %s to %s",
+					_PATH_RMTABTMP, _PATH_RMTAB);
+		}
+	} else {
+		unlink(_PATH_RMTABTMP);
+	}
+	xfunlock(rmtab_lockid);
+	xfunlock(etab_lockid);
+
+	/* cleanup list of exported paths */
+	for (i = 0; i < len; i++)
+		free(e_path[i]);
+	if (e_path)
+		free(e_path);
 }

--- a/support/include/exportfs.h
+++ b/support/include/exportfs.h
@@ -171,6 +171,8 @@ struct addrinfo *		host_numeric_addrinfo(const struct sockaddr *sap);
 
 int				rmtab_read(void);
 
+void				rmtab_rebuild(void);
+
 struct nfskey *			key_lookup(char *hname);
 
 struct export_features {


### PR DESCRIPTION
# Problem:
In order to automatically disable NFSv3 services we need to know if clients are still using NFSv3 mounts. One such way is to look at the `/var/lib/nfs/rmtab` file.

The `rpc.mountd` daemon registers every successful **MNT** request by adding an entry to the `/var/lib/nfs/rmtabfile`. And when receiving a **UMNT** request from an NFS client, `rpc.mountd` then removes the matching entry from `rmtab`. However, if the client performs a lazy unmount or reboots without sending an **UMNT** request, stale entries can remain for that client in the `rmtab` file.
# Solution:
Make the `rmtab` file accurate so it can be used in determining if NFSv3 services are still required. When the NFS exports are being rebuilt in `exportfs`, also rebuild the `rmtab` file.  Every NFSv3 client mount represented in `rmtab` should have a corresponding entry in the list of exports, otherwise it is a stale entry and should be removed.
# Testing
Verified with an appstack that is now checking `rmtab` before disabling NFSv3 services (**DLPX-78014**).  As expected the services are disabled when the last VDB using NFSv3 is disabled.

Verified that the stale entries in `rmtab` file (due to using lazy unmounts in the client) are cleaned up when the export is removed (setting sharenfs=off).

Manually verified that stale entries are being removed when the NFS exports are rebuilt.

Also confirmed that we log the stale entries that got purged:
```
delphix@ip-10-110-233-246:~$ sudo grep exportfs-log /var/log/syslog
Nov 11 22:15:48 ip-10-110-233-246 exportfs-log[565008]: purged stale rmtab entry '10.110.239.63:/domain0/group-2/oracle_db_container-6/oracle_timeflow-888/datafile'
Nov 11 22:15:48 ip-10-110-233-246 exportfs-log[565008]: purged stale rmtab entry '10.110.239.63:/domain0/group-2/oracle_db_container-6/oracle_timeflow-888/archive'
Nov 11 22:15:48 ip-10-110-233-246 exportfs-log[565008]: purged stale rmtab entry '10.110.239.63:/domain0/group-2/oracle_db_container-6/oracle_timeflow-888/external'
Nov 11 22:15:48 ip-10-110-233-246 exportfs-log[565008]: purged stale rmtab entry '10.110.239.63:/domain0/group-2/oracle_db_container-6/oracle_timeflow-888/temp'
```