### PR TITLE
DLPX-84998 Remove 'rmtab' from list of delivered files

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -24,7 +24,6 @@ ACLOCAL_AMFLAGS = -I aclocal
 install-data-hook:
 	if [ ! -d $(DESTDIR)$(statedir) ]; then mkdir -p $(DESTDIR)$(statedir); fi
 	touch $(DESTDIR)$(statedir)/xtab; chmod 644 $(DESTDIR)$(statedir)/xtab
-	touch $(DESTDIR)$(statedir)/rmtab; chmod 644 $(DESTDIR)$(statedir)/rmtab
 	mkdir -p $(DESTDIR)$(statdpath)/sm $(DESTDIR)$(statdpath)/sm.bak
 	touch $(DESTDIR)$(statdpath)/state
 	chmod go-rwx $(DESTDIR)$(statdpath)/sm $(DESTDIR)$(statdpath)/sm.bak $(DESTDIR)$(statdpath)/state

--- a/Makefile.in
+++ b/Makefile.in
@@ -887,7 +887,6 @@ uninstall-am:
 install-data-hook:
 	if [ ! -d $(DESTDIR)$(statedir) ]; then mkdir -p $(DESTDIR)$(statedir); fi
 	touch $(DESTDIR)$(statedir)/xtab; chmod 644 $(DESTDIR)$(statedir)/xtab
-	touch $(DESTDIR)$(statedir)/rmtab; chmod 644 $(DESTDIR)$(statedir)/rmtab
 	mkdir -p $(DESTDIR)$(statdpath)/sm $(DESTDIR)$(statdpath)/sm.bak
 	touch $(DESTDIR)$(statdpath)/state
 	chmod go-rwx $(DESTDIR)$(statdpath)/sm $(DESTDIR)$(statdpath)/sm.bak $(DESTDIR)$(statdpath)/state

--- a/debian/nfs-kernel-server.install
+++ b/debian/nfs-kernel-server.install
@@ -3,7 +3,6 @@ debian/tmp/sbin/nfsdcltrack
 debian/tmp/usr/sbin/rpc.mountd
 debian/tmp/usr/sbin/rpc.nfsd
 debian/tmp/var/lib/nfs/xtab
-debian/tmp/var/lib/nfs/rmtab
 debian/nfs-kernel-server.default /usr/share/nfs-kernel-server/conffiles/
 debian/etc.exports /usr/share/nfs-kernel-server/conffiles/
 systemd/nfs-blkmap.service /lib/systemd/system

--- a/debian/nfs-kernel-server.lintian-overrides
+++ b/debian/nfs-kernel-server.lintian-overrides
@@ -1,2 +1,1 @@
 nfs-kernel-server: file-missing-in-md5sums var/lib/nfs/xtab
-nfs-kernel-server: file-missing-in-md5sums var/lib/nfs/rmtab


### PR DESCRIPTION
<details open>
<summary><h2> Background </h2></summary>

The `nfs-kernel-server` package has the `rmtab` file delivered as part of the package. When upgrading the package, the existing file gets replaced with a new/empty `rmtab` file from the package.

This file is dynamically modified during runtime, to contain the list of active NFSv3 client mounts. Thus, when it's replaced on upgrade with an empty file, this can result in NFSv3 services being disabled since it appears that there are no active NFSv3 mounts.

This is problematic, since the act of disabling NFSv3 services will result in client errors, if those mounts are being actively used at the time of the upgrade.
</details>

<details open>
<summary><h2> Solution </h2></summary>

This PR removes the `rmtab` file from the list of files delivered by the `nfs-kernel-server` package.
</details>

<details>
<summary><h2> Testing Done </h2></summary>

http://selfservice.jenkins.delphix.com/job/appliance-build-orchestrator-pre-push/4720/

Manual upgrade testing in progress...
</details>